### PR TITLE
fix #179: Add permission check logic to API

### DIFF
--- a/src/main/java/com/bluestarfish/blueberry/comment/controller/CommentController.java
+++ b/src/main/java/com/bluestarfish/blueberry/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.bluestarfish.blueberry.comment.service.CommentService;
 import com.bluestarfish.blueberry.common.dto.ApiSuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,9 +26,10 @@ public class CommentController {
 
     @PostMapping
     public ApiSuccessResponse<?> registerComment(
-            @RequestBody CommentRequest commentRequest
+            @RequestBody CommentRequest commentRequest,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        commentService.createComment(commentRequest);
+        commentService.createComment(commentRequest, accessToken);
         return handleSuccessResponse(HttpStatus.CREATED);
     }
 
@@ -42,9 +44,10 @@ public class CommentController {
     @DeleteMapping("/{postId}/{commentId}")
     public ApiSuccessResponse<?> deleteComment(
             @PathVariable("postId") Long postId,
-            @PathVariable("commentId") Long commentId
+            @PathVariable("commentId") Long commentId,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        commentService.deleteCommentById(postId, commentId);
+        commentService.deleteCommentById(postId, commentId, accessToken);
         return handleSuccessResponse(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/bluestarfish/blueberry/comment/service/CommentService.java
+++ b/src/main/java/com/bluestarfish/blueberry/comment/service/CommentService.java
@@ -5,7 +5,7 @@ import com.bluestarfish.blueberry.comment.dto.CommentResponse;
 import org.springframework.data.domain.Page;
 
 public interface CommentService {
-    void createComment(CommentRequest commentRequest);
+    void createComment(CommentRequest commentRequest, String accessToken);
     Page<CommentResponse> getAllCommentsByPostId(Long postId, int page);
-    void deleteCommentById(Long postId, Long commentId);
+    void deleteCommentById(Long postId, Long commentId, String accessToken);
 }

--- a/src/main/java/com/bluestarfish/blueberry/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/bluestarfish/blueberry/comment/service/CommentServiceImpl.java
@@ -5,10 +5,13 @@ import com.bluestarfish.blueberry.comment.dto.CommentResponse;
 import com.bluestarfish.blueberry.comment.entity.Comment;
 import com.bluestarfish.blueberry.comment.exception.CommentException;
 import com.bluestarfish.blueberry.comment.repository.CommentRepository;
+import com.bluestarfish.blueberry.jwt.JWTUtils;
 import com.bluestarfish.blueberry.post.entity.Post;
 import com.bluestarfish.blueberry.post.repository.PostRepository;
 import com.bluestarfish.blueberry.user.entity.User;
 import com.bluestarfish.blueberry.user.repository.UserRepository;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,13 +30,20 @@ public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final JWTUtils jwtUtils;
 
     @Override
-    public void createComment(CommentRequest commentRequest) {
+    public void createComment(CommentRequest commentRequest, String accessToken) {
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
+
         Post post = postRepository.findById(commentRequest.getPostId())
                 .orElseThrow(() -> new CommentException("Post not found with id: " + commentRequest.getPostId(), HttpStatus.NOT_FOUND));
         User user = userRepository.findByIdAndDeletedAtIsNull(commentRequest.getUserId())
                 .orElseThrow(() -> new CommentException("User not found with id: " + commentRequest.getUserId(), HttpStatus.NOT_FOUND));
+
+        if(!tokenId.equals(user.getId())) {
+            throw new CommentException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
 
         if(commentRequest.getMentionId() != null) {
             User mentionedUser = userRepository.findByIdAndDeletedAtIsNull(commentRequest.getMentionId())
@@ -52,7 +62,16 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public void deleteCommentById(Long postId, Long commentId) {
+    public void deleteCommentById(Long postId, Long commentId, String accessToken) {
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
+
+        User user = postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new CommentException("Post not found with id: " + postId, HttpStatus.NOT_FOUND)).getUser();
+
+        if(!tokenId.equals(user.getId())) {
+            throw new CommentException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
+
         Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
                 .orElseThrow(() -> new CommentException("Comment not found with id: " + commentId, HttpStatus.NOT_FOUND));
         comment.setDeletedAt(LocalDateTime.now());

--- a/src/main/java/com/bluestarfish/blueberry/common/repository/UserRoomRepository.java
+++ b/src/main/java/com/bluestarfish/blueberry/common/repository/UserRoomRepository.java
@@ -11,4 +11,5 @@ public interface UserRoomRepository extends JpaRepository<UserRoom, Long>, UserR
 
     Optional<UserRoom> findByRoomIdAndUserId(Long roomId, Long userId);
     List<UserRoom> findByRoomIdAndIsActiveTrue(Long roomId);
+    UserRoom findByRoomIdAndIsHostTrue(Long id);
 }

--- a/src/main/java/com/bluestarfish/blueberry/post/controller/PostController.java
+++ b/src/main/java/com/bluestarfish/blueberry/post/controller/PostController.java
@@ -8,6 +8,7 @@ import com.bluestarfish.blueberry.post.enumeration.PostType;
 import com.bluestarfish.blueberry.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -27,9 +28,10 @@ public class PostController {
 
     @PostMapping
     public ApiSuccessResponse<?> registerPost(
-            @RequestBody PostRequest postRequest
+            @RequestBody PostRequest postRequest,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        postService.createPost(postRequest);
+        postService.createPost(postRequest, accessToken);
         return handleSuccessResponse(HttpStatus.CREATED);
     }
 
@@ -52,17 +54,19 @@ public class PostController {
     @PatchMapping("/{postId}")
     public ApiSuccessResponse<?> updatePost(
             @PathVariable("postId") Long id,
-            @RequestBody PostRequest postRequest
+            @RequestBody PostRequest postRequest,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        postService.updatePostById(id, postRequest);
+        postService.updatePostById(id, postRequest, accessToken);
         return handleSuccessResponse(HttpStatus.OK);
     }
 
     @DeleteMapping("/{postId}")
     public ApiSuccessResponse<?> deletePost(
-            @PathVariable("postId") Long id
+            @PathVariable("postId") Long id,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        postService.deletePostById(id);
+        postService.deletePostById(id, accessToken);
         return handleSuccessResponse(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/bluestarfish/blueberry/post/service/PostService.java
+++ b/src/main/java/com/bluestarfish/blueberry/post/service/PostService.java
@@ -7,9 +7,9 @@ import com.bluestarfish.blueberry.post.enumeration.PostType;
 import org.springframework.data.domain.Page;
 
 public interface PostService {
-    void createPost(PostRequest postRequest);
+    void createPost(PostRequest postRequest, String accessToken);
     PostResponse getPostById(Long id);
     Page<PostResponse> getAllPosts(int page, PostType postType, boolean isRecruited);
-    void updatePostById(Long id, PostRequest postRequest);
-    void deletePostById(Long id);
+    void updatePostById(Long id, PostRequest postRequest, String accessToken);
+    void deletePostById(Long id, String accessToken);
 }

--- a/src/main/java/com/bluestarfish/blueberry/post/service/PostServiceImpl.java
+++ b/src/main/java/com/bluestarfish/blueberry/post/service/PostServiceImpl.java
@@ -1,17 +1,19 @@
 package com.bluestarfish.blueberry.post.service;
 
+import com.bluestarfish.blueberry.jwt.JWTUtils;
 import com.bluestarfish.blueberry.post.dto.PostRequest;
 import com.bluestarfish.blueberry.post.dto.PostResponse;
 import com.bluestarfish.blueberry.post.entity.Post;
 import com.bluestarfish.blueberry.post.enumeration.PostType;
 import com.bluestarfish.blueberry.post.exception.PostException;
 import com.bluestarfish.blueberry.post.repository.PostRepository;
-import com.bluestarfish.blueberry.room.dto.RoomResponse;
 import com.bluestarfish.blueberry.room.entity.Room;
 import com.bluestarfish.blueberry.room.repository.RoomRepository;
 import com.bluestarfish.blueberry.room.service.RoomService;
 import com.bluestarfish.blueberry.user.entity.User;
 import com.bluestarfish.blueberry.user.repository.UserRepository;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -32,11 +34,17 @@ public class PostServiceImpl implements PostService {
     private final UserRepository userRepository;
     private final RoomRepository roomRepository;
     private final RoomService roomService;
+    private final JWTUtils jwtUtils;
 
     @Override
-    public void createPost(PostRequest postRequest) {
+    public void createPost(PostRequest postRequest, String accessToken) {
         User user = userRepository.findByIdAndDeletedAtIsNull(postRequest.getUserId())
                 .orElseThrow(() -> new PostException("User not fount with id: " + postRequest.getUserId(), HttpStatus.NOT_FOUND));
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
+        if(!tokenId.equals(user.getId())) {
+            throw new PostException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
+
         Post post;
 
         if(postRequest.getRoomId() != null) {
@@ -107,7 +115,13 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public void updatePostById(Long id, PostRequest postRequest) {
+    public void updatePostById(Long id, PostRequest postRequest, String accessToken) {
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
+
+        if(!tokenId.equals(postRequest.getUserId())) {
+            throw new PostException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
+
         Post post = postRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new PostException("Post not found with id: " + id, HttpStatus.NOT_FOUND));
         if(postRequest.getRoomId() != null) {
@@ -123,9 +137,14 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public void deletePostById(Long id) {
+    public void deletePostById(Long id, String accessToken) {
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
         Post post = postRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new PostException("Post not found with id: " + id, HttpStatus.NOT_FOUND));
+
+        if(!tokenId.equals(post.getUser().getId())) {
+            throw new PostException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
         post.setDeletedAt(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/bluestarfish/blueberry/room/controller/RoomController.java
+++ b/src/main/java/com/bluestarfish/blueberry/room/controller/RoomController.java
@@ -8,6 +8,7 @@ import com.bluestarfish.blueberry.room.dto.RoomRequest;
 import com.bluestarfish.blueberry.room.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,12 +27,11 @@ public class RoomController {
 
     @PostMapping
     public ApiSuccessResponse<?> registerStudyRoom(
-
-            @RequestBody RoomRequest roomRequest
+            @RequestBody RoomRequest roomRequest,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        roomService.createRoom(roomRequest);
+        roomService.createRoom(roomRequest, accessToken);
         return handleSuccessResponse(HttpStatus.CREATED);
-
     }
 
     @GetMapping("/{roomId}")
@@ -59,9 +59,10 @@ public class RoomController {
 
     @DeleteMapping("/{roomId}")
     public ApiSuccessResponse<?> deleteStudyRoom(
-            @PathVariable("roomId") Long id
+            @PathVariable("roomId") Long id,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        roomService.deleteRoomById(id);
+        roomService.deleteRoomById(id, accessToken);
         return handleSuccessResponse(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/bluestarfish/blueberry/room/service/RoomService.java
+++ b/src/main/java/com/bluestarfish/blueberry/room/service/RoomService.java
@@ -8,11 +8,11 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 
 public interface RoomService {
-    void createRoom(RoomRequest roomRequest);
+    void createRoom(RoomRequest roomRequest, String accessToken);
     RoomDetailResponse getRoomById(Long id);
     Page<RoomResponse> getAllRooms(int page, String keyword, Boolean isCanEnabled);
     List<RoomResponse> getMyRooms(Long userId);
-    void deleteRoomById(Long id);
+    void deleteRoomById(Long id, String accessToken);
     void entranceRoom(Long roomId, Long userId, UserRoomRequest userRoomRequest);
     void exitRoom(Long roomId, Long userId, UserRoomRequest userRoomRequest);
     int getActiveMemberCount(Long roomId);

--- a/src/main/java/com/bluestarfish/blueberry/user/controller/UserController.java
+++ b/src/main/java/com/bluestarfish/blueberry/user/controller/UserController.java
@@ -46,17 +46,19 @@ public class UserController {
     @PatchMapping(path = "/{userId}", consumes = "multipart/form-data")
     public ApiSuccessResponse<?> update(
             @PathVariable("userId") Long id,
-            @ModelAttribute UserUpdateRequest userUpdateRequest
+            @ModelAttribute UserUpdateRequest userUpdateRequest,
+            @CookieValue(name = "Authorization") String accessToken
     ) throws IOException {
-        userService.update(id, userUpdateRequest);
+        userService.update(id, userUpdateRequest, accessToken);
         return handleSuccessResponse(HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping("/{userId}")
     public ApiSuccessResponse<?> withdraw(
-            @PathVariable("userId") Long id
+            @PathVariable("userId") Long id,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        userService.withdraw(id);
+        userService.withdraw(id, accessToken);
         return handleSuccessResponse(HttpStatus.NO_CONTENT);
     }
 
@@ -70,9 +72,10 @@ public class UserController {
 
     @PatchMapping("/password")
     public ApiSuccessResponse<?> resetPassword(
-            @RequestBody PasswordResetRequest passwordResetRequest
+            @RequestBody PasswordResetRequest passwordResetRequest,
+            @CookieValue(name = "Authorization") String accessToken
     ) {
-        userService.resetPassword(passwordResetRequest);
+        userService.resetPassword(passwordResetRequest, accessToken);
         return handleSuccessResponse(HttpStatus.NO_CONTENT);
     }
 

--- a/src/main/java/com/bluestarfish/blueberry/user/service/UserService.java
+++ b/src/main/java/com/bluestarfish/blueberry/user/service/UserService.java
@@ -14,12 +14,12 @@ public interface UserService {
 
     UserResponse findById(Long id);
 
-    void update(Long id, UserUpdateRequest userUpdateRequest) throws IOException;
+    void update(Long id, UserUpdateRequest userUpdateRequest, String accessToken) throws IOException;
 
-    void withdraw(Long id);
+    void withdraw(Long id, String accessToken);
 
     void validateNickname(String nickname);
 
-    void resetPassword(PasswordResetRequest passwordResetRequest);
+    void resetPassword(PasswordResetRequest passwordResetRequest, String accessToken);
 
 }

--- a/src/main/java/com/bluestarfish/blueberry/user/service/UserServiceImpl.java
+++ b/src/main/java/com/bluestarfish/blueberry/user/service/UserServiceImpl.java
@@ -66,11 +66,17 @@ public class UserServiceImpl implements UserService {
     @Override
     public void update(
             Long id,
-            UserUpdateRequest userUpdateRequest
+            UserUpdateRequest userUpdateRequest,
+            String accessToken
     ) throws IOException {
         User user = userRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(
                 () -> new UserException("A user with " + id + " not found", HttpStatus.NOT_FOUND)
         );
+
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
+        if(!tokenId.equals(user.getId())) {
+            throw new UserException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
 
         // FIXME: 이후 리팩토링
         String imagePath = null;
@@ -106,12 +112,17 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void withdraw(
-            Long id
+            Long id,
+            String accessToken
     ) {
         User user = userRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(
                         () -> new UserException("A user with " + id + " not found", HttpStatus.NOT_FOUND)
                 );
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
+        if(!tokenId.equals(user.getId())) {
+            throw new UserException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
 
         user.setDeletedAt(LocalDateTime.now());
     }
@@ -125,12 +136,16 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void resetPassword(PasswordResetRequest passwordResetRequest) {
+    public void resetPassword(PasswordResetRequest passwordResetRequest, String accessToken) {
         User user = userRepository.findByEmailAndDeletedAtIsNull(passwordResetRequest.getEmail())
                 .orElseThrow(
                         () -> new UserException("A user with " + passwordResetRequest.getEmail() + " not found",
                                 HttpStatus.NOT_FOUND)
                 );
+        Long tokenId = jwtUtils.getId(URLDecoder.decode(accessToken, StandardCharsets.UTF_8));
+        if(!tokenId.equals(user.getId())) {
+            throw new UserException("Not match request ID and login ID", HttpStatus.UNAUTHORIZED);
+        }
 
         user.setPassword(passwordEncoder.encode(passwordResetRequest.getPassword()));
     }


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
api에서 본인 아이디를 확인해서 요청을 날렸을때 확인하는 로직 추가

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #179 
