### PR TITLE
feat #224: Add Valid to title, content size in PostRequestDTO, 게시글 생성 시 글자 수 검증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Valid
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/bluestarfish/blueberry/post/controller/PostController.java
+++ b/src/main/java/com/bluestarfish/blueberry/post/controller/PostController.java
@@ -6,6 +6,7 @@ import com.bluestarfish.blueberry.common.dto.ApiSuccessResponse;
 import com.bluestarfish.blueberry.post.dto.PostRequest;
 import com.bluestarfish.blueberry.post.enumeration.PostType;
 import com.bluestarfish.blueberry.post.service.PostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -28,7 +29,7 @@ public class PostController {
 
     @PostMapping
     public ApiSuccessResponse<?> registerPost(
-            @RequestBody PostRequest postRequest,
+            @Valid @RequestBody PostRequest postRequest,
             @CookieValue(name = "Authorization") String accessToken
     ) {
         postService.createPost(postRequest, accessToken);

--- a/src/main/java/com/bluestarfish/blueberry/post/dto/PostRequest.java
+++ b/src/main/java/com/bluestarfish/blueberry/post/dto/PostRequest.java
@@ -4,6 +4,8 @@ import com.bluestarfish.blueberry.post.entity.Post;
 import com.bluestarfish.blueberry.post.enumeration.PostType;
 import com.bluestarfish.blueberry.room.entity.Room;
 import com.bluestarfish.blueberry.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,8 +21,15 @@ public class PostRequest {
     private Long id;
     private Long userId;
     private Long roomId;
+
+    @NotBlank(message = "Title must not be blank")
+    @Size(min = 5, max = 20, message = "Title must be between 5 and 20 characters")
     private String title;
+
+    @NotBlank(message = "Content must not be blank")
+    @Size(min = 5, max = 200, message = "Content must be between 5 and 200 characters")
     private String content;
+
     private PostType type;
     private Boolean isRecruited;
     private boolean postCamEnabled;


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
커뮤니티 게시글 생성 시 제목, 내용에 대해서 글자 수 제한 검증 로직 추가

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->
- Resolves #224 
