### PR TITLE
fix: change how to get friends list API

### DIFF
--- a/src/main/java/com/bluestarfish/blueberry/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/bluestarfish/blueberry/notification/repository/NotificationRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByReceiverIdAndDeletedAtIsNull(Long receiverId);
 
-    List<Notification> findByReceiverIdAndNotiTypeAndNotiStatusAndDeletedAtIsNull(Long receiverId, NotiType notiType, NotiStatus notiStatus);
+    List<Notification> findByReceiverIdAndNotiTypeAndNotiStatus(Long receiverId, NotiType notiType, NotiStatus notiStatus);
 
-    List<Notification> findBySenderIdAndNotiTypeAndNotiStatusAndDeletedAtIsNull(Long senderId, NotiType notiType, NotiStatus notiStatus);
+    List<Notification> findBySenderIdAndNotiTypeAndNotiStatus(Long senderId, NotiType notiType, NotiStatus notiStatus);
 }

--- a/src/main/java/com/bluestarfish/blueberry/notification/service/NoticeServiceImpl.java
+++ b/src/main/java/com/bluestarfish/blueberry/notification/service/NoticeServiceImpl.java
@@ -136,7 +136,7 @@ public class NoticeServiceImpl implements NoticeService {
     public List<UserResponse> getFriendsList(Long userId) {
         // 1. 친구 추가 요청을 받은사람(Receiver)가 본인(userId)일 때
         List<Notification> notifications = notificationRepository
-                .findByReceiverIdAndNotiTypeAndNotiStatusAndDeletedAtIsNull(userId, NotiType.FRIEND, NotiStatus.ACCEPTED);
+                .findByReceiverIdAndNotiTypeAndNotiStatus(userId, NotiType.FRIEND, NotiStatus.ACCEPTED);
 
         // 그러면 Sender의 정보를 전달해야함
         List<UserResponse> userSenderResponses = notifications.stream()
@@ -147,7 +147,7 @@ public class NoticeServiceImpl implements NoticeService {
                 .toList();
 
         // 2. 친구 추가 요청을 받은사람이 상대(Receiver)일때, 즉 내(userId)가 친구 추가 요청을 보냈을때(Sender)
-        notifications = notificationRepository.findBySenderIdAndNotiTypeAndNotiStatusAndDeletedAtIsNull(userId, NotiType.FRIEND, NotiStatus.ACCEPTED);
+        notifications = notificationRepository.findBySenderIdAndNotiTypeAndNotiStatus(userId, NotiType.FRIEND, NotiStatus.ACCEPTED);
 
         // 그러면 Receiver의 정보 전달
         List<UserResponse> userReceiverResponses = notifications.stream()


### PR DESCRIPTION
### Description

<!--
  간단하게 PR의 목적을 설명하세요.
  이 PR이 해결하려는 문제나 추가하려는 기능에 대해 요약해주세요.
-->
- 친구목록 조회시 deletedAt 항목 여부는 조회하지 않도록 변경
- 친구삭제와 알림삭제를 구분하기 위함.